### PR TITLE
added ToC option to livescript2markdown (revised)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Use `livescript2markdown` function to convert mlx-script to md-file.
    -  `'FixLinks'`: convert file links with `open`, `winopen`, `cd` into suitable markdown format.  It can be `true` (default) or `false` 
    -  `'NormalizeLines'`: remove extra empty lines in generated file.  It can be `true` (default) or `false` 
    -  `'AddMention'`: mention this toolbox at the end of generated file.  It can be `false` (default) or `true` 
+   -  `'ToC'`: add a table of contents at the beginning of generated file.  It can be `false` (default) or `true` 
 
 ## Output arguments
 

--- a/main/code/livescript2markdown.m
+++ b/main/code/livescript2markdown.m
@@ -12,6 +12,7 @@ arguments
     opts.FixLinks (1,1) logical = true % Fix MATLAB special links
     opts.NormalizeLines (1,1) logical = true % Remove extra empty lines
     opts.AddMention (1,1) logical = false % Add toolbox mention
+    opts.ToC (1,1) logical = false % Add a table of content
 end
 
 if mdFilePath == ""
@@ -60,7 +61,8 @@ prevWorkFolder = cd(workFolder);
 
 % Prepare latex to markdown conversion parameters
 argOpts = struct('outputfilename', mdFileName, 'format', opts.Format, ...
-    'png2jpeg', opts.Png2jpeg, 'tableMaxWidth', opts.TableMaxWidth);
+    'png2jpeg', opts.Png2jpeg, 'tableMaxWidth', opts.TableMaxWidth, ...
+    'ToC', opts.ToC);
 args = namedargs2cell(argOpts);
 % Call latex2markdown function (convert latex to markdown)
 mdFileNameExt = latex2markdown(latexFileAbsPath, args{:});


### PR DESCRIPTION
A user of the tool requested a feature to add a table of contents on the generated markdown file. The necessary changes have been made to latex2markdown on https://github.com/minoue-xx/livescript2markdown, it would be great if we could add an option to your livescript2markdown.m